### PR TITLE
Fix build script issues and to update the rmdir to rm as its obsolete now

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -66,19 +66,22 @@ fs.writeFileSync(path.join(robsim, 'manifest.json'), JSON.stringify({
     package_version: require('../package.json').version,
     total_package_size: totalPackageSize.toString().padStart(20, '0'),
 }, null, 2));
+
 // delete directory recursively if it exists
-fs.rmdir(robsim_dest, { recursive: true }, (err) => {
-    if (err) {
-        throw err;
+fs.rm(robsim_dest, { recursive: true }, (err) => {
+    if (err && err.errno != -4058) {
+        //throw err;
+        console.error(err);
     }
 
     console.log(`${robsim_dest} is deleted!`);
-});
-// To copy a folder or file  
-fse.copy(robsim, robsim_dest, function (err) {
-    if (err){
-        console.log('An error occurred while copying the folder.')
-        return console.error(err)
-    }
-    console.log('Copy completed!')
+
+    // To copy a folder or file  
+    fse.copy(robsim, robsim_dest, function (err) {
+        if (err){
+            console.log('An error occurred while copying the folder.')
+            return console.error(err)
+        }
+        console.log('Copy completed!')
+    });
 });


### PR DESCRIPTION
Updated the npm run build  "build.js" to use the new async way of making the release package and to change the rmdir to rm (as rmdir is obsolete in node.js).